### PR TITLE
Uptime should be long instead of TimeSpan/string, because it's easier to consume…

### DIFF
--- a/src/Collector.Common.Heartbeat/Collector.Common.Heartbeat.csproj
+++ b/src/Collector.Common.Heartbeat/Collector.Common.Heartbeat.csproj
@@ -7,7 +7,7 @@
     <Authors>Team Pacifier</Authors>
     <Description></Description>
     <RepositoryType>git</RepositoryType>
-    <Version>2.1.0</Version>
+    <Version>2.1.1</Version>
     <RepositoryUrl>https://github.com/collector-bank/common-heartbeat</RepositoryUrl>
     <PackageProjectUrl>https://github.com/collector-bank/common-heartbeat</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/collector-bank/common-heartbeat/master/heartbeat.png</PackageIconUrl>

--- a/src/Collector.Common.Heartbeat/DiagnosticsResult.cs
+++ b/src/Collector.Common.Heartbeat/DiagnosticsResult.cs
@@ -59,7 +59,7 @@ namespace Collector.Common.Heartbeat
 
     public class ProcessInformation
     {
-        public TimeSpan Uptime { get; set; }
+        public long UptimeMilliseconds { get; set; }
         public DateTime StartTime { get; set; }
     }
 

--- a/src/Collector.Common.Heartbeat/HeartbeatMiddleware.cs
+++ b/src/Collector.Common.Heartbeat/HeartbeatMiddleware.cs
@@ -128,7 +128,7 @@ namespace Collector.Common.Heartbeat
             return new ProcessInformation
             {
                 StartTime = currentProcess.StartTime,
-                Uptime = DateTime.Now.Subtract(currentProcess.StartTime)
+                UptimeMilliseconds = (long)DateTime.Now.Subtract(currentProcess.StartTime).TotalMilliseconds
             };
         }
 


### PR DESCRIPTION
… an integer in elasticsearch.